### PR TITLE
Add more tests to pyxrf

### DIFF
--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -26,6 +26,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -26,14 +26,6 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
-
-# Install the yum requirements defined canonically in the
-# "recipe/yum_requirements.txt" file. After updating that file,
-# run "conda smithy rerender" and this line will be updated
-# automatically.
-/usr/bin/sudo -n yum install -y mesa-libGL
-
-
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - atom
-    - databroker <1.0
+    - databroker <1
     - enaml >=0.10.3
     - h5py
     - ipywidgets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pyxrf = pyxrf.gui:run
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
@@ -34,14 +34,20 @@ requirements:
     - pandas
     - pillow
     - pyqt >=5.9.2
-    - scipy
-    - six
+    # - requests
     - scikit-beam >=0.0.17
     - scikit-image
+    - scipy
+    - six
 
 test:
   imports:
-    - {{ name }}
+    - pyxrf
+    - pyxrf.db_config
+    - pyxrf.model
+    - pyxrf.view
+  commands:
+    - pyxrf --help
 
 about:
   home: https://github.com/NSLS-II/pyxrf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,6 @@ test:
     - pyxrf
     - pyxrf.api
     - pyxrf.db_config
-    - pyxrf.db_config.hxn_db_config
-    - pyxrf.db_config.srx_db_config
-    - pyxrf.db_config.xfm_db_config
     - pyxrf.gui
     - pyxrf.model
     - pyxrf.model.command_tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,25 @@ requirements:
 test:
   imports:
     - pyxrf
+    - pyxrf.api
     - pyxrf.db_config
+    - pyxrf.db_config.hxn_db_config
+    - pyxrf.db_config.srx_db_config
+    - pyxrf.db_config.xfm_db_config
+    - pyxrf.gui
     - pyxrf.model
+    - pyxrf.model.command_tools
+    - pyxrf.model.data_to_analysis_store
+    - pyxrf.model.draw_image
+    - pyxrf.model.draw_image_rgb
+    - pyxrf.model.fileio
+    - pyxrf.model.fit_spectrum
+    - pyxrf.model.guessparam
+    - pyxrf.model.lineplot
+    - pyxrf.model.load_data_from_db
+    - pyxrf.model.param_data
+    - pyxrf.model.setting
+    - pyxrf.model.utils
     - pyxrf.view
   commands:
     - pyxrf --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python
     - atom
+    - databroker <1.0
     - enaml >=0.10.3
     - h5py
     - ipywidgets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,8 +61,6 @@ test:
     - pyxrf.model.setting
     - pyxrf.model.utils
     - pyxrf.view
-  commands:
-    - pyxrf --help
 
 about:
   home: https://github.com/NSLS-II/pyxrf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   run:
     - python
     - atom
-    - databroker <1
     - enaml >=0.10.3
     - h5py
     - ipywidgets
@@ -45,7 +44,6 @@ test:
   imports:
     - pyxrf
     - pyxrf.api
-    - pyxrf.db_config
     - pyxrf.gui
     - pyxrf.model
     - pyxrf.model.command_tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pandas
     - pillow
     - pyqt >=5.9.2
-    # - requests
+    - requests
     - scikit-beam >=0.0.17
     - scikit-image
     - scipy

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-mesa-libGL

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL


### PR DESCRIPTION
Same version number, more tests.

The `requests` dependency will be eventually added this dependency was introduces in https://github.com/NSLS-II/PyXRF/pull/182/.