### PR TITLE
v0.0.27: Pinned version of 'enaml' and 'atom'

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pyxrf = pyxrf.gui:run
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
@@ -23,8 +23,8 @@ requirements:
     - pip
   run:
     - python
-    - atom
-    - enaml >=0.10.3
+    - atom ==0.4.3
+    - enaml ==0.10.4
     - h5py >=2.9.0
     - ipywidgets
     - jsonschema


### PR DESCRIPTION
Hope to fix mess with installation of enaml/atom. New versions of enaml are available only from conda-forge, but new versions of atom are still put on anaconda. When pyxrf is installed from nsls2forge, then the incompatible combination of older version of enaml and new version of atom is installed. In this PR the versions of enaml and atom are pinned to older version.