### PR TITLE
Revert h5py>=2.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - pyxrf = pyxrf.gui:run
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
@@ -27,7 +27,7 @@ requirements:
     - dask
     - distributed
     - enaml ==0.10.4
-    - h5py >=2.8.0
+    - h5py >=2.9.0
     - ipywidgets
     - jsonschema
     - jupyter


### PR DESCRIPTION
Reverts the changes to the dependencies brought via https://github.com/nsls-ii-forge/pyxrf-feedstock/commit/8f641f832d7e57d50dd4dfc29f89b1fb4484b579.